### PR TITLE
fix Exception bug

### DIFF
--- a/netsim/generate.py
+++ b/netsim/generate.py
@@ -120,7 +120,7 @@ def check(df):
         
         # raise exception if any errors        
         if error_flag:
-            raise('\nCheck errors !!! Network simulation ABORTED!! ')    
+            raise Exception('\nCheck errors !!! Network simulation ABORTED!! ')    
     else:
         print('\n No corrections or errors !! ')
 


### PR DESCRIPTION
this fixes a tiny bug in the `Exception` definition. Because Python threw an error in the correct place, it wasn't obvious that there was a problem with the exception statement itself.

<img width="1022" alt="Screen Shot 2019-11-05 at 3 46 28 PM" src="https://user-images.githubusercontent.com/28818837/68256280-7e69cc80-ffe4-11e9-87eb-56e10dbeded3.png">
